### PR TITLE
Permit annotations on secrets

### DIFF
--- a/templates/dockerhub-secret.yaml
+++ b/templates/dockerhub-secret.yaml
@@ -4,6 +4,9 @@ kind: Secret
 metadata:
   name: {{ include "common.fullname" ( dict "root" . "service" .Values ) }}-dockerregistry
   labels: {{ include "common.labels" ( dict "root" . "service" .Values ) | nindent 4 }}
+{{- with $.Values.annotations }}
+  annotations: {{- . | toYaml | nindent 4 }}
+{{- end }}
 type: kubernetes.io/dockerconfigjson
 data:
   .dockerconfigjson: {{ include "secrets.dockerregistry" . | b64enc }}

--- a/templates/secret.yaml
+++ b/templates/secret.yaml
@@ -5,6 +5,9 @@ kind: Secret
 metadata:
   name: {{ include "common.fullname" ( dict "root" $ "service" $.Values ) }}
   labels: {{ include "common.labels" ( dict "root" $ "service" $.Values ) | nindent 4 }}
+{{- with $.Values.annotations }}
+  annotations: {{- . | toYaml | nindent 4 }}
+{{- end }}
 type: generic
 data:
 {{- range $key, $value := . }}


### PR DESCRIPTION
Occasionally it's useful to annotate a secret -- e.g. to permit kubernetes-replicator to know that it should be doing something with it. This change allows annotations to be added to the created secrets.